### PR TITLE
Update qbraid.ipynb

### DIFF
--- a/qbraid.ipynb
+++ b/qbraid.ipynb
@@ -23,7 +23,7 @@
     "# \"%%capture\" (above) captures and in this case, hides the output of this\n",
     "# cell, so you can comment it out if you need help debugging this step.\n",
     "\n",
-    "%pip install 'qbraid[runtime]' matplotlib"
+    "%pip install qbraid matplotlib"
    ]
   },
   {


### PR DESCRIPTION
When https://github.com/ionq-samples/getting-started/pull/49 was merged, qBraid-SDK v0.7 was still in pre-release, which is why the integration tests failed.

qBraid-SDK v0.7 has now been [released](https://pypi.org/project/qbraid/), and you no longer need to install the `qbraid[runtime]` extra to import the `qbraid.runtime.ionq.IonQProvider`. In fact, the `runtime` extra doesn't exist anymore. All of the necessary requirements to use the `IonQProvider` are now included in the qBraid-SDK's core dependencies.

See also: https://docs.qbraid.com/sdk/user-guide/providers/ionq